### PR TITLE
Check version number of used CF standard

### DIFF
--- a/atmodat_checker/atmodat_checklib/register/nc_file_checks_atmodat_register.py
+++ b/atmodat_checker/atmodat_checklib/register/nc_file_checks_atmodat_register.py
@@ -22,6 +22,30 @@ class NCFileCheckBase(CallableCheckBase):
             raise FileError("Object for testing is not a netCDF4 Dataset: {}".format(str(primary_arg)))
 
 
+class CFConventionsVersionCheck(NCFileCheckBase):
+    """
+    The version number of CF-Conventions in the global attribute '{attribute}' must be 1.4 or greater.
+    """
+    short_name = "Global attribute: {attribute}"
+    defaults = {}
+    required_args = ['attribute']
+    message_templates = ["'{status}' '{attribute}' global attribute is not present.",
+                         "Invald CF Convention version number in '{attribute}' global attribute"]
+
+    def _get_result(self, primary_arg):
+        ds = primary_arg
+
+        cf_min_version = 1.4
+        score = nc_util.check_cfconventions_version_number(ds, self.kwargs["attribute"], cf_min_version)
+        messages = []
+
+        if score < self.out_of:
+            messages.append(self.get_messages()[score])
+
+        return Result(self.level, (score, self.out_of),
+                      self.get_short_name(), messages)
+
+
 class GobalAttrResolutionFormatCheck(NCFileCheckBase):
     """
     The global attribute '{attribute}' must be in number+unit format .

--- a/atmodat_checker/atmodat_checklib/utils/nc_util.py
+++ b/atmodat_checker/atmodat_checklib/utils/nc_util.py
@@ -4,6 +4,39 @@ import re
 from cfunits import Units
 
 
+def check_cfconventions_version_number(ds, attr, cf_min_version):
+    """
+    Checks global attribute values in a NetCDF Dataset and returns integer
+    regarding whether the `attr` matches number+unit format
+
+    :param ds: netCDF4 Dataset object
+    :param attr: global attribute name [string]
+    :param cf_min_version: Minimum version number needed
+    :return: Integer (0: incorrect format; 1: correct format).
+    """
+
+    if attr not in ds.ncattrs():
+        return 0
+    global_attr = getattr(ds, attr)
+
+    cf_version = None
+    if ',' in global_attr:
+        global_attr_split = global_attr.split(',')
+        for conv in global_attr_split:
+            if 'cf' in conv.lower():
+                cf_version = float(re.findall(r"[+]?\d*\.\d+|\d+", conv)[0])
+    else:
+        global_attr_split = global_attr.split(' ')
+        for conv in global_attr_split:
+            if 'cf' in conv.lower():
+                cf_version = float(re.findall(r"[+]?\d*\.\d+|\d+", conv)[0])
+
+    if cf_version < cf_min_version:
+        return 1
+    else:
+        return 2
+
+
 def check_global_attr_type(ds, attr, attr_type):
     """
     Checks globals attribute values in a NetCDF Dataset and returns integer

--- a/atmodat_standard_checker_mandatory.yml
+++ b/atmodat_standard_checker_mandatory.yml
@@ -22,3 +22,9 @@ checks:
   - check_id: "source_attribute_type_check"
     parameters: {"attribute": "source", "type": str, "status": "mandatory"}
     check_name: "atmodat_checklib.register.GlobalAttrTypeCheck"
+
+  # 3. Check if CF-Conventions Version is 1.4 or greater
+
+  - check_id: "cf_conventions_version_check"
+    parameters: {"attribute": "Conventions", "type": str, "status": "mandatory"}
+    check_name: "atmodat_checklib.register.CFConventionsVersionCheck"


### PR DESCRIPTION
This PR checks whether the CF version number given in the Conventions attribute is1.4 or greater. In principle, this can be simply be extended to check other version numbers given in other attributes (e.g. atmodat-x.y)